### PR TITLE
Fixing Nim 1.2 issues and arduino portability

### DIFF
--- a/spryvm/spryextend.nim
+++ b/spryvm/spryextend.nim
@@ -1,4 +1,4 @@
-import spryvm
+import spryvm, options
 # Example extending Spry with multiline string literals similar to Nim but using
 # triple single quotes ''' ... ''' and no skipping whitespace/newline after
 # the first delimiter. Its just an example, adding support for """ was harder
@@ -26,11 +26,11 @@ proc prefixLength(self: MultilineStringValueParser): int = 3
 method tokenStart(self: ValueParser, s: string, c: char): bool =
   s == "''" and c == '\''
 
-method tokenReady(self: MultilineStringValueParser, token: string, c: char): string =
+method tokenReady(self: MultilineStringValueParser, token: string, c: char): Option[string] =
   if c == '\'' and token.len > 4 and token[^2..^1] == "''":
-    return token & c
+    return some(token & c)
   else:
-    return nil
+    return none(string)
 
 # This proc does the work extending the Parser instance
 proc extendParser(p: Parser) {.procvar.} =

--- a/spryvm/sprymath.nim
+++ b/spryvm/sprymath.nim
@@ -1,5 +1,8 @@
 import spryvm
-import math, random
+import math
+
+when not defined(spryMathNoRandom):
+  import random
 
 # Spry math module
 proc addMath*(spry: Interpreter) =
@@ -15,12 +18,13 @@ proc addMath*(spry: Interpreter) =
   nimMeth("powerOfTwo?"): newValue(isPowerOfTwo(IntVal(evalArgInfix(spry)).value))
   nimMeth("nextPowerOfTwo"): newValue(nextPowerOfTwo(IntVal(evalArgInfix(spry)).value))
   # nimMeth("sum", false): newValue(sum(SeqComposite(evalArg(spry)).value))
-  nimMeth("random"):
-    let max = evalArgInfix(spry)
-    if max of FloatVal:
-      return newValue(rand(FloatVal(max).value))
-    else:
-      return newValue(rand(IntVal(max).value))
+  when not defined(spryMathNoRandom):
+    nimMeth("random"):
+      let max = evalArgInfix(spry)
+      if max of FloatVal:
+        return newValue(rand(FloatVal(max).value))
+      else:
+        return newValue(rand(IntVal(max).value))
   nimMeth("sqrt"):
     let self = evalArgInfix(spry)
     if self of FloatVal:

--- a/spryvm/spryoo.nim
+++ b/spryvm/spryoo.nim
@@ -22,7 +22,7 @@ method eval*(self: PolyMeth, spry: Interpreter): Node =
   if tags.isNil:
     return spry.nilVal
   let nodeTags = tags.nodes
-  if nodeTags.isNil:
+  if nodeTags.len == 9:
     return spry.nilVal
   for n in self.nodes:
     let funTags = Funk(n).tags.nodes

--- a/spryvm/spryvm.nim
+++ b/spryvm/spryvm.nim
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015 Göran Krampe
 
-import strutils, sequtils, tables, hashes
+import strutils, sequtils, tables, hashes, options
 
 const
   # These characters do not need whitespace to be recognized as tokens,
@@ -563,7 +563,7 @@ method parseValue(self: StringValueParser, s: string): Node {.procvar.} =
 
 method prefixLength(self: ValueParser): int {.base.} = 0
 
-method tokenReady(self: ValueParser, token: string, ch: char): string {.base.} =
+method tokenReady(self: ValueParser, token: string, ch: char): Option[string] {.base.} =
   ## Return true if self wants to take over parsing a literal
   ## and deciding when its complete. This is used for delimited literals
   ## that can contain whitespace. Otherwise parseValue is needed.
@@ -577,12 +577,12 @@ method prefixLength(self: StringValueParser): int = 1
 method tokenStart(self: StringValueParser, token: string, ch: char): bool =
   ch == '"'
 
-method tokenReady(self: StringValueParser, token: string, ch: char): string =
+method tokenReady(self: StringValueParser, token: string, ch: char): Option[string] =
   # Minimally two '"' and the previous char was not '\'
   if ch == '"' and token[^1] != '\\':
-    return token & ch
+    return some(token & ch)
   else:
-    return nil
+    return none(string)
 
 proc newParser*(): Parser =
   ## Create a new Spry parser with the basic value parsers included
@@ -793,8 +793,8 @@ proc parse*(self: Parser, str: string): Node =
       # If we are inside a literal value let the valueParser decide when complete
       if currentValueParser.notNil:
         let found = currentValueParser.tokenReady(self.token, ch)
-        if found.notNil:
-          self.token = found
+        if found.isSome:
+          self.token = found.get()
           self.addNode()
           currentValueParser = nil
         else:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,3 +2,4 @@
 all
 spry*test
 test.db
+all.dSYM/

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -12,3 +12,4 @@ import sprymemfiletest
 import spryextendtest
 import spryjsontest
 import sprysqlitetest
+import spryrocksdbtest

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -12,4 +12,3 @@ import sprymemfiletest
 import spryextendtest
 import spryjsontest
 import sprysqlitetest
-import spryrocksdbtest

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -5,6 +5,5 @@ linedir = on
 debuginfo
 stacktrace = on
 linetrace = on
-nilseqs = on
 multimethods:on
 -d:nimOldCaseObjects

--- a/tests/sprycoretest.nim
+++ b/tests/sprycoretest.nim
@@ -399,7 +399,7 @@ suite "spry core":
 
   test "lib":
     # Library code
-    check run("assert (3 < 4)") == "true"
+    check run("assert (3 < 4) \"failed\"") == "true"
 
   test "clone":
     check run("a = 12 b = clone a a = 9 eva b") == "12"

--- a/tests/sprycoretest.nim
+++ b/tests/sprycoretest.nim
@@ -26,9 +26,9 @@ suite "spry core":
     check run("{}") == "{}"
     check run("{} empty?") == "true"
     check run("{x = 1} empty?") == "false"
-    check run("{a = 1 b = 2}") == "{a = 1 b = 2}"
-    check run("{a = 1 b = \"hey\"}") == "{a = 1 b = \"hey\"}"
-    check run("{a = {d = (3 + 4) e = (5 + 6)}}") == "{a = {d = 7 e = 11}}"
+    check run("{a = 1 b = 2}") in ["{a = 1 b = 2}", "{b = 2 a = 1}"]
+    check run("{a = 1 b = \"hey\"}") in ["{a = 1 b = \"hey\"}", "{b = \"hey\" a = 1}"]
+    check run("{a = {d = (3 + 4) e = (5 + 6)}}") in ["{a = {d = 7 e = 11}}", "{a = {e = 11 d = 7}}"]
     check run("{a = 3} at: 'a") == "3"
     check run("{3 = 4 6 = 1} at: 6") == "1" # int, In spry any Node can be a key!
     check run("{\"hey\" = 4 true = 1 6.0 = 8} at: \"hey\"") == "4" # string


### PR DESCRIPTION
- Changed nil strings to use Option. This fixes issues when compiling to C++ backend which is useful on Arduino. Also closer to modern default Nim behavior.
- Fix Map unit tests to account for possibly unordered Table behavior. 
- Added `spryMathNoRandom` flag to not import random which pulls in `os` on Arduino causing issues 
